### PR TITLE
Handle more IRC formatting codes

### DIFF
--- a/lib/pyborg/pyborg-irc.py
+++ b/lib/pyborg/pyborg-irc.py
@@ -341,7 +341,7 @@ note, notes, drink, google"
         if body.find("\033") != -1: return
 
         #remove special irc fonts chars
-        body = re.sub("[\x02\xa0]", "", body)
+        body = re.sub("[\x02\x0f\x1d\x1f\xa0]", "", body)
 
         # WHOOHOOO!!
         if target == self.settings.myname or source == self.settings.myname:


### PR DESCRIPTION
0x0F reset
0x1D italic
0x1F underline

new bridge sends `\x02<user>\x0F message` rather than `\x02<user>\x02 message`, so this needs to handle 0x0F for commands to work, otherwise the first character in every message from the bridge is a space